### PR TITLE
Ee 6825 basic auth

### DIFF
--- a/kd/job.yaml
+++ b/kd/job.yaml
@@ -27,5 +27,4 @@ spec:
               secretKeyRef:
                 name: pttg-ip-api-service-secrets
                 key: pttg_ip_smoke_tests
-
       restartPolicy: Never

--- a/kd/job.yaml
+++ b/kd/job.yaml
@@ -20,6 +20,12 @@ spec:
             cpu: 100m
             memory: 968Mi
         env:
-          name: IP_API_ROOT_URL
-          value: https://pttg-ip-api.{{.KUBE_NAMESPACE}}.svc.cluster.local
+          - name: IP_API_ROOT_URL
+            value: https://pttg-ip-api.{{.KUBE_NAMESPACE}}.svc.cluster.local
+          - name: IP_API_AUTH
+            valueFrom:
+              secretKeyRef:
+                name: pttg-ip-api-service-secrets
+                key: pttg_ip_smoke_tests
+
       restartPolicy: Never


### PR DESCRIPTION
Inject the required basic auth credentials into the smoke test as an environment variable. The values are stored in a config map and I've already set them up in dev, test and prod.