### PR TITLE
EE-6825 updated config for IPS endpoint and basicauth

### DIFF
--- a/kd/deployment.yaml
+++ b/kd/deployment.yaml
@@ -34,9 +34,9 @@ spec:
               cpu: 100m
               memory: 968Mi
           env:
-            - name: IP_API_ROOT_URL
-              value: https://pttg-ip-api.{{.KUBE_NAMESPACE}}.svc.cluster.local
-            - name: IP_API_AUTH
+            - name: IPS_ENDPOINT
+              value: https://pttg-ip-api.{{.KUBE_NAMESPACE}}.svc.cluster.local:8080/smoketests
+            - name: IPS_BASICAUTH
               valueFrom:
                 secretKeyRef:
                   name: pttg-ip-api-service-secrets


### PR DESCRIPTION
 to align with smoke-test changes. Accompanies https://github.com/UKHomeOffice/pttg-ip-smoke-tests/pull/18