### PR TITLE
Ee 6825 add trust store

### DIFF
--- a/kd/deployment.yaml
+++ b/kd/deployment.yaml
@@ -76,6 +76,10 @@ spec:
           ports:
             - name: http
               containerPort: 8080
+          volumeMounts:
+            - mountPath: /etc/keystore
+              name: keystore
+              readOnly: true
       volumes:
         - name: keystore
           emptyDir:

--- a/kd/deployment.yaml
+++ b/kd/deployment.yaml
@@ -71,6 +71,8 @@ spec:
                   key: pttg_ip_smoke_tests
             - name: JAVA_OPTS
               value: '-Xms150m -Xmx250m -Djavax.net.ssl.trustStore=/etc/keystore/truststore.jks'
+            - name: JDK_TRUST_FILE
+              value: '/etc/keystore/truststore.jks'
           ports:
             - name: http
               containerPort: 8080

--- a/kd/deployment.yaml
+++ b/kd/deployment.yaml
@@ -23,6 +23,34 @@ spec:
     spec:
       imagePullSecrets:
         - name: registrykey
+      initContainers:
+        - name: truststore
+          image: quay.io/ukhomeofficedigital/cfssl-sidekick-jks:v0.0.7
+          securityContext:
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - SETUID
+                - SETGID
+          args:
+            - --certs=/certs
+            - --command=/usr/bin/create-keystore.sh /certs/tls.pem /certs/tls-key.pem /etc/ssl/certs/acp-root.crt
+            - --domain=pttg-ip-smoke-tests.${KUBE_NAMESPACE}.svc.cluster.local
+            - --domain=localhost
+            - --onetime=true
+          env:
+          - name: KUBE_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          volumeMounts:
+          - name: certs
+            mountPath: /certs
+          - name: keystore
+            mountPath: /etc/keystore
+          - name: bundle
+            mountPath: /etc/ssl/certs
+            readOnly: true
       containers:
         - name: pttg-ip-smoke-tests
           image: quay.io/ukhomeofficedigital/pttg-ip-smoke-tests:{{.VERSION}}
@@ -44,3 +72,13 @@ spec:
           ports:
             - name: http
               containerPort: 8080
+      volumes:
+        - name: keystore
+          emptyDir:
+            medium: "Memory"
+        - name: certs
+          emptyDir:
+            medium: "Memory"
+        - name: bundle
+          configMap:
+            name: bundle

--- a/kd/deployment.yaml
+++ b/kd/deployment.yaml
@@ -69,6 +69,8 @@ spec:
                 secretKeyRef:
                   name: pttg-ip-api-service-secrets
                   key: pttg_ip_smoke_tests
+            - name: JAVA_OPTS
+              value: '-Xms150m -Xmx250m -Djavax.net.ssl.trustStore=/etc/keystore/truststore.jks'
           ports:
             - name: http
               containerPort: 8080


### PR DESCRIPTION
Adds an initcontainer to setup the java trustore to trust the Root CA used in ACP i.e. makes SSL work between pods.