### PR TITLE
EE-6825 Fix endpoint for IPS API 

### DIFF
--- a/kd/deployment.yaml
+++ b/kd/deployment.yaml
@@ -63,7 +63,7 @@ spec:
               memory: 968Mi
           env:
             - name: IPS_ENDPOINT
-              value: https://pttg-ip-api.{{.KUBE_NAMESPACE}}.svc.cluster.local/smoketests
+              value: https://pttg-ip-api.{{.KUBE_NAMESPACE}}.svc.cluster.local/incomeproving/v3/individual/financialstatus
             - name: IPS_BASICAUTH
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
- path should have been /incomeproving/v3/individual/financialstatus not /smoketests